### PR TITLE
Add SQUASH_PR_TITLE to sync squash-merge pr title option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
           MERGE_COMMIT: 'true'
           REBASE_MERGE: 'true'
           DELETE_HEAD: 'false'
+          SQUASH_PR_TITLE: 'false'
           BRANCHES_PROTECTION_NAME: |
             'master'
             'dev'
@@ -60,6 +61,7 @@ jobs:
 | MERGE_COMMIT | false | true | Whether or not to allow merge commits on the repo |
 | REBASE_MERGE | false | true | Whether or not to allow rebase merges on the repo |
 | DELETE_HEAD | false | false | Whether or not to delete head branch after merges |
+| SQUASH_PR_TITLE | false | false | Whether or not to use the PR title as default commit name when using squash-merge |
 | BRANCHES_PROTECTION_NAME | false | 'master' | Branches name pattern for branch protection rule |
 | BRANCH_PROTECTION_REQUIRED_REVIEWERS | false | 1 | Number of required reviewers for branch protection rule |
 | BRANCH_PROTECTION_DISMISS | false | true | Dismiss stale pull request approvals when new commits are pushed |

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Whether or not to delete head branch after merges'
     required: false
     default: 'false'
+  SQUASH_PR_TITLE:
+    description: 'Whether or not to use the PR title as default commit name when using squash-merge'
+    required: false
+    default: 'false'
   BRANCHES_PROTECTION_NAME:
     description: 'Branches name pattern for branches protection rule'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,8 @@ REBASE_MERGE=$INPUT_REBASE_MERGE
 echo "Rebase Merge           : $REBASE_MERGE"
 DELETE_HEAD=$INPUT_DELETE_HEAD
 echo "Delete Head            : $DELETE_HEAD"
+SQUASH_PR_TITLE=$INPUT_SQUASH_PR_TITLE
+echo "Squash PR title        : $SQUASH_PR_TITLE"
 RAW_BRANCHES_PROTECTION_NAME="$INPUT_BRANCHES_PROTECTION_NAME"
 BRANCHES_PROTECTION_NAME=($RAW_BRANCHES_PROTECTION_NAME)
 echo "Branches Protection Name : $BRANCHES_PROTECTION_NAME"
@@ -92,6 +94,7 @@ for repository in "${REPOSITORIES[@]}"; do
     --argjson mergeCommit $MERGE_COMMIT \
     --argjson rebaseMerge $REBASE_MERGE \
     --argjson deleteHead $DELETE_HEAD \
+    --argjson squashPrTitle $SQUASH_PR_TITLE \
     '{
         has_issues:$allowIssues,
         has_projects:$allowProjects,
@@ -100,6 +103,7 @@ for repository in "${REPOSITORIES[@]}"; do
         allow_merge_commit:$mergeCommit,
         allow_rebase_merge:$rebaseMerge,
         delete_branch_on_merge:$deleteHead,
+        use_squash_pr_title_as_default:$squashPrTitle,
     }' \
     | curl -d @- \
         -X PATCH \


### PR DESCRIPTION
[Announcement](https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/#:~:text=You%20can%20now%20default%20to,title%20for%20squash%20merge%20commits).

[API Doc](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository).